### PR TITLE
Fix package updating

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.1.2
+  - 2.2.0
 bundler_args: --without development --without kitchen_vagrant
 cache: bundler
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.1.2'
+ruby '2.2.0'
 
 gem 'foodcritic'
 gem 'rubocop'

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -15,16 +15,25 @@ when 'rhel', 'fedora'
     gpgcheck false
     sslverify true
     sslcacert '/etc/pki/tls/certs/ca-bundle.crt'
-    action :create
+    action [:create, :makecache]
     only_if { node['blackfire']['install_repository'] }
   end
 else
-  apt_repository 'blackfire' do
+  r = apt_repository 'blackfire' do
     uri "#{node[cookbook_name]['repository']}/#{node['platform']}"
     distribution 'any'
     key 'https://packagecloud.io/gpg.key'
     components ['main']
-    action :add
+    action :nothing
     only_if { node['blackfire']['install_repository'] }
+  end
+  r.run_action(:add)
+
+  unless r.updated?
+    execute 'blackfire repository update' do
+      command "apt-get update -o Dir::Etc::sourcelist='sources.list.d/#{r.name}.list' -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0'"
+      ignore_failure true
+      action :run
+    end
   end
 end


### PR DESCRIPTION
Currently the cookbook forces the installation of the most recent version retrieved via the API.
However the local APT cache can be not up-to-date and so the package installation fails.

With this PR we are sure that the blackfire repository is always up-to-date before installing the package.
