### PR TITLE
Missing probe credentials config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.1.2
+  - 2.2.0
 bundler_args: --without development --without kitchen_vagrant
 cache: bundler
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.1.2'
+ruby '2.2.0'
 
 gem 'foodcritic'
 gem 'rubocop'

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The following attributes are available to affect the installation/configuration 
 * `node['blackfire']['php']['log_level']` - Sets the logging level for the PHP extension.
 * `node['blackfire']['php']['log_file']` - Sets where the PHP extension write logs.
 * `node['blackfire']['php']['ini_path']` - Sets where the PHP configuration will be written.
+* `node['blackfire']['php']['server_id']` - Sets the Server ID to use for probe fine-grained configuration (See https://blackfire.io/doc/configuration#probe-configuration)
+* `node['blackfire']['php']['server_id']` - Sets the Server Token to use for probe fine-grained configuration (See https://blackfire.io/doc/configuration#probe-configuration)
 
 Usage
 -----

--- a/attributes/php.rb
+++ b/attributes/php.rb
@@ -9,6 +9,8 @@ default['blackfire']['php']['version'] = nil
 default['blackfire']['php']['agent_timeout'] = '0.25'
 default['blackfire']['php']['log_level'] = nil
 default['blackfire']['php']['log_file'] = nil
+default['blackfire']['php']['server_id'] = nil
+default['blackfire']['php']['server_token'] = nil
 
 if platform_family?('rhel', 'fedora')
   default['blackfire']['php']['ini_path'] = '/etc/php.d/zz-blackfire.ini'

--- a/recipes/php.rb
+++ b/recipes/php.rb
@@ -33,7 +33,9 @@ template node[cookbook_name]['php']['ini_path'] do
     'agent_timeout' => node[cookbook_name]['php']['agent_timeout'],
     'log_file' => node[cookbook_name]['php']['log_file'],
     'log_level' => node[cookbook_name]['php']['log_level'],
-    'socket' => node[cookbook_name]['agent']['socket']
+    'socket' => node[cookbook_name]['agent']['socket'],
+    'server_id' => node[cookbook_name]['php']['server_id'],
+    'server_token' => node[cookbook_name]['php']['server_token']
   )
   notifies :run, 'ruby_block[blackfire-php-restart-webserver]', :immediately
 end

--- a/templates/default/blackfire.ini.erb
+++ b/templates/default/blackfire.ini.erb
@@ -3,8 +3,16 @@
 extension=blackfire.so
 blackfire.agent_socket = <%= @socket %>
 blackfire.agent_timeout = <%= @agent_timeout %>
+<% if @server_id %>
+blackfire.server_id = <%= @server_id %>
+<% else %>
 ;blackfire.server_id =
+<% end %>
+<% if @server_token %>
+blackfire.server_token = <%= @server_token %>
+<% else %>
 ;blackfire.server_token =
+<% end %>
 <% if @log_level %>
 blackfire.log_level = <%= @log_level %>
 <% else %>


### PR DESCRIPTION
Probe's `server_id` and `server_token` were not in use when releasing the first version of this cookbook and so were forgotten.
