### PR TITLE
Prevent restart with no server credentials which causes exit code 1

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -31,8 +31,8 @@ template '/etc/blackfire/agent' do
 end
 
 service 'blackfire-agent' do
-  not_if { node[cookbook_name]['agent']['server_id'].empty? }
-  not_if { node[cookbook_name]['agent']['server_token'].empty? }
+  not_if { node[cookbook_name]['agent']['server_id'].to_s == '' }
+  not_if { node[cookbook_name]['agent']['server_token'].to_s == '' }
   supports status: true, start: true, stop: true, restart: true
   action [:enable]
   subscribes :restart, 'template[/etc/blackfire/agent]',  node[cookbook_name]['agent']['restart_mode']

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -31,8 +31,8 @@ template '/etc/blackfire/agent' do
 end
 
 service 'blackfire-agent' do
-  not_if { node[cookbook_name]['agent']['server_id'].to_s == '' }
-  not_if { node[cookbook_name]['agent']['server_token'].to_s == '' }
+  not_if { node[cookbook_name]['agent']['server_id'].to_s.empty? }
+  not_if { node[cookbook_name]['agent']['server_token'].to_s.empty? }
   supports status: true, start: true, stop: true, restart: true
   action [:enable]
   subscribes :restart, 'template[/etc/blackfire/agent]',  node[cookbook_name]['agent']['restart_mode']

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -31,6 +31,8 @@ template '/etc/blackfire/agent' do
 end
 
 service 'blackfire-agent' do
+  not_if { node[cookbook_name]['agent']['server_id'].empty? }
+  not_if { node[cookbook_name]['agent']['server_token'].empty? }
   supports status: true, start: true, stop: true, restart: true
   action [:enable]
   subscribes :restart, 'template[/etc/blackfire/agent]',  node[cookbook_name]['agent']['restart_mode']


### PR DESCRIPTION
This is a solution for someone who wants to install blackfire without setting the server credentials right away, such as in public vagrant boxes. Prior to this, on server restart, chef-solo would exit due to exit code 1 from the service restart operation, and the provisioning would fail.